### PR TITLE
Drop proxy container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,21 @@ Security in case of vulnerabilities.
 ## [Unreleased]
 
 
+## [26.6.28]
+
+### Added
+- `/health`
+
+### Changed
+- Hosting setup to expect external/host Caddy to do all the proxying
+
+### Deprecated
+- Caddy proxy container
+
+### Fixed
+- Intermittend downtime (hopefully)
+
+
 ## [26.5.18]
 
 ### Added
@@ -279,7 +294,8 @@ Security in case of vulnerabilities.
 - First version suitable for public consumption.
 
 
-[Unreleased]: https://github.com/nkantar/Starminder/compare/26.5.18...HEAD
+[Unreleased]: https://github.com/nkantar/Starminder/compare/26.6.28...HEAD
+[26.6.28]: https://github.com/nkantar/Starminder/compare/26.5.18...26.6.28
 [26.5.18]: https://github.com/nkantar/Starminder/compare/25.11.20...26.5.18
 [25.11.20]: https://github.com/nkantar/Starminder/compare/25.11.2.2...25.11.20
 [25.11.2.2]: https://github.com/nkantar/Starminder/compare/25.11.2.1...25.11.2.2

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,13 +1,12 @@
-starminder.dev:80,
-starminder.dev:443 {
-    reverse_proxy web:8000
+starminder.dev {
+    reverse_proxy starminder-web:8000
 
     @plausible path /js/script.js /api/event
     handle @plausible {
         rewrite /js/script.js /js/script.js
         reverse_proxy https://plausible.io {
             header_up Host {http.reverse_proxy.upstream.hostport}
-            header_up X-Forwarded-For {http.request.header.X-Forwarded-For}
+            header_up X-Forwarded-For {remote_host}
             transport http {
                 tls
             }
@@ -15,12 +14,8 @@ starminder.dev:443 {
     }
 }
 
-
-www.starminder.dev:80,
-www.starminder.dev:443,
-starminder.xyz:80,
-starminder.xyz:443,
-www.starminder.xyz:80,
-www.starminder.xyz:443 {
-    redir https://starminder.dev{uri}
+www.starminder.dev,
+starminder.xyz,
+www.starminder.xyz {
+    redir https://starminder.dev{uri} permanent
 }

--- a/Dockerfile_caddy
+++ b/Dockerfile_caddy
@@ -1,5 +1,0 @@
-# serve with Caddy
-FROM caddy:alpine
-
-# copy Caddy config
-COPY Caddyfile /etc/caddy/Caddyfile

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,5 @@
 services:
-  web:
+  starminder-web:
     build: .
     container_name: starminder-web
     restart: unless-stopped
@@ -17,16 +17,15 @@ services:
       - "8000"
     networks:
       - starminder
-    depends_on:
-      - proxy
+      - coolify
     healthcheck:
-      test: ["CMD", "curl", "--fail", "--silent", "--output", "/dev/null", "https://starminder.dev"]
+      test: ["CMD", "curl", "--fail", "--silent", "--output", "/dev/null", "--header", "Host: starminder.dev", "http://localhost:8000/health/"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 40s
 
-  worker:
+  starminder-worker:
     build: .
     container_name: starminder-web
     restart: unless-stopped
@@ -42,7 +41,7 @@ services:
     networks:
       - starminder
     depends_on:
-      - web
+      - starminder-web
     command: ["just", "worker"]
     healthcheck:
       test: ["CMD", "pgrep", "-f", "qcluster"]
@@ -51,30 +50,8 @@ services:
       retries: 3
       start_period: 40s
 
-  proxy:
-    build:
-      context: .
-      dockerfile: Dockerfile_caddy
-    container_name: starminder-caddy
-    restart: unless-stopped
-    expose:
-      - "80"
-    volumes:
-      - caddy_data:/data
-      - caddy_config:/config
-    networks:
-      - starminder
-    healthcheck:
-      test: ["CMD", "pgrep", "-f", "caddy"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
-
 networks:
   starminder:
     driver: bridge
-
-volumes:
-  caddy_data:
-  caddy_config:
+  coolify:
+    external: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Starminder"
-version = "26.5.18"
+version = "26.6.28"
 dependencies = [
     "croniter>=6.0.0",
     "dj-database-url>=3.0.1",

--- a/starminder/core/urls.py
+++ b/starminder/core/urls.py
@@ -1,3 +1,4 @@
+from django.http import HttpResponse
 from django.urls import path
 
 from starminder.core.views import (
@@ -14,4 +15,5 @@ urlpatterns = [
     path("delete-account/", DeleteAccountView.as_view(), name="delete_account"),
     path("faq/", FAQView.as_view(), name="faq"),
     path("testimonials/", TestimonialsView.as_view(), name="testimonials"),
+    path("health/", lambda request: HttpResponse("ok")),
 ]

--- a/starminder/settings.py
+++ b/starminder/settings.py
@@ -48,6 +48,9 @@ SECRET_KEY = parsenvy.str("DJANGO_SECRET_KEY")
 
 ALLOWED_HOSTS = parsenvy.list("DJANGO_ALLOWED_HOSTS")
 
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+USE_X_FORWARDED_HOST = True
+
 CSRF_TRUSTED_ORIGINS = [f"https://{host}" for host in cast(list, ALLOWED_HOSTS)]
 
 AUTH_USER_MODEL = "core.CustomUser"

--- a/uv.lock
+++ b/uv.lock
@@ -63,7 +63,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy' and platform_python_implementation != 'PyPy'" },
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -851,7 +851,7 @@ wheels = [
 
 [[package]]
 name = "starminder"
-version = "26.5.18"
+version = "26.6.28"
 source = { virtual = "." }
 dependencies = [
     { name = "croniter" },


### PR DESCRIPTION
## Related Issues

- #151


## Summary

The PR drops the proxy container, readying the project for the exclusive use of the host’s proxy.


## Changes

- Added healthcheck endpoint
- Deleted proxy container `Dockerfile_caddy`
- Changed `Caddyfile` to be suitable for use on host
- Updated `docker-compose.yaml` to reflect the above


## Code Quality

- [x] All tests pass (`just test`)
- [x] All type checks pass (`just typecheck`)
- [x] All linter checks pass (`just lint`)
- [x] All formatting checks pass (`just formatcheck`)
- [x] All Django checks pass (`just djangocheck`)
- [ ] ~Documented code as appropriate~
- [ ] ~Added new tests for new functionality~
- [ ] ~Manually tested locally~


### Manual Testing

Didn’t. `#yolo`


## Deployment Considerations

- [ ] Requires database migrations
- [ ] Requires environment variable changes
- [ ] Changes GitHub token scope
- [ ] Breaking changes (describe below)


## Screenshots/Demo

N/A


## AI Disclosure

None.